### PR TITLE
Fix Error Not Being Hidden

### DIFF
--- a/script.js
+++ b/script.js
@@ -28,6 +28,7 @@ $("#bannerForm").submit(function(event) {
   };
 
   $spinnerOverlay.fadeIn();
+  $errorOverlay.hide();
   banner.src = url;
 });
 


### PR DESCRIPTION
Currently once an error is displayed, it is not hidden when the banner generates successfully.